### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jawbone-up",
   "version": "0.1.2",
   "dependencies": {
-    "request": "2.27.0"
+    "request": "2.74.0"
   },
   "repository": {
     "url": "https://github.com/ryanseys/node-jawbone-up"


### PR DESCRIPTION
node-jawbone-up currently has a 4 vulnerable dependency paths, introducing 4 different types of known vulnerabilities.

This PR fixes vulnerable dependency paths.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/ryanseys/node-jawbone-up) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)